### PR TITLE
security: disable postinstall/lifecycle scripts via .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Requires Grafana 12.3 or later; updated for React 19 compatibility.
 
+### Project Updates
+
+- Added `.npmrc` with `ignore-scripts=true` to disable lifecycle scripts and mitigate supply-chain attack risk.
+
 ## [5.1.0] - 2025-10-29
 
 ### Project Updates


### PR DESCRIPTION
## Why

Lifecycle scripts (`postinstall`, `prepare`, etc.) run arbitrary code during `npm install` and are a common
supply-chain attack vector. Disabling them reduces risk from compromised transitive dependencies.

## What changed

- Added `.npmrc` with `ignore-scripts=true` to disable lifecycle scripts globally for this project.
- Added a `### Project Updates` entry to the `[Unreleased]` changelog section.

## Notes

No dependencies in `package-lock.json` declare lifecycle scripts that are required for correct operation,
so existing installs are unaffected.

## References

- [npm docs — lifecycle scripts](https://docs.npmjs.com/cli/v10/using-npm/scripts#a-note-on-a-common-anti-pattern)