### PR TITLE
chore: bump plugin-ci-workflows to ci-cd-workflows/v8.0.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
   cd:
     name: CD
     needs: stamp-changelog
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v8.0.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v8.0.1
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
Bumps `plugin-ci-workflows` from `ci-cd-workflows/v8.0.0` to `ci-cd-workflows/v8.0.1`.

**Changes in v8.0.1:**
- fix: install `jq` via apk in publish-docs step (docs-base is alpine)
- chore: bump `pnpm/action-setup` from v5.0.0 to v6.0.8